### PR TITLE
Port setup to sugar3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
-from sugar.activity import bundlebuilder
+from sugar3.activity import bundlebuilder
 if __name__ == "__main__":
     bundlebuilder.start()


### PR DESCRIPTION
When porting activities to Gtk3, the setup must also
be ported to sugar3.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
