### PR TITLE
Remove recursion

### DIFF
--- a/Letters.py
+++ b/Letters.py
@@ -194,11 +194,8 @@ class Letters:
         buttons.off('back')
         buttons.Button('help', (cx, cy))
 
-    def g_init(self):
-        g.init()
-
     def run(self, restore=False):
-        self.g_init()
+        g.init()
         if not self.journal:
             utils.load()
         self.let = let.Let()

--- a/Letters.py
+++ b/Letters.py
@@ -194,8 +194,11 @@ class Letters:
         buttons.off('back')
         buttons.Button('help', (cx, cy))
 
-    def run(self, restore=False):
+    def g_init(self):
         g.init()
+
+    def run(self, restore=False):
+        self.g_init()
         if not self.journal:
             utils.load()
         self.let = let.Let()

--- a/activity.py
+++ b/activity.py
@@ -128,8 +128,6 @@ class PeterActivity(activity.Activity):
                                  Gdk.Screen.height() - GRID_CELL_SIZE),
                                 pygame.RESIZABLE)
 
-        self.game.run(restore=True)
-
     def _button_cb(self, button=None, color=None):
         self.game.do_button(color)
 

--- a/activity.py
+++ b/activity.py
@@ -127,7 +127,7 @@ class PeterActivity(activity.Activity):
         pygame.display.set_mode((Gdk.Screen.width(),
                                  Gdk.Screen.height() - GRID_CELL_SIZE),
                                 pygame.RESIZABLE)
-        self.game.g_init()
+
         self.game.run(restore=True)
 
     def _button_cb(self, button=None, color=None):

--- a/activity.py
+++ b/activity.py
@@ -127,7 +127,7 @@ class PeterActivity(activity.Activity):
         pygame.display.set_mode((Gdk.Screen.width(),
                                  Gdk.Screen.height() - GRID_CELL_SIZE),
                                 pygame.RESIZABLE)
-
+        self.game.g_init()
         self.game.run(restore=True)
 
     def _button_cb(self, button=None, color=None):


### PR DESCRIPTION
Fixes #3 

Test method
1) Run activity with `sugar-activity`
2) Open Ubuntu Displays setting
3) Change orientation from landscape to any of the other options
4) Use the activity and make words with the letters (No traceback is observed)
5) Rotate display back to landscape
6) Use activity (No traceback is observed)
7) Stop activity

The activity terminates normally with no process left running. No traceback is observed.

Tested on Sugar v0.114 and Ubuntu 18.04